### PR TITLE
feat: inject sql in python strings

### DIFF
--- a/nvim/after/queries/python/injections.scm
+++ b/nvim/after/queries/python/injections.scm
@@ -1,0 +1,8 @@
+; extends
+
+; Inject SQL into any Python string that looks like SQL.
+; Matches triple-quoted strings too (they are still `string` with `string_content`).
+(string
+  (string_content) @injection.content
+  (#set! injection.language "sql")
+  (#set! injection.combined))

--- a/nvim/lua/baggiponte/lsp.lua
+++ b/nvim/lua/baggiponte/lsp.lua
@@ -82,3 +82,15 @@ vim.api.nvim_create_autocmd('LspAttach', {
     end
   end,
 })
+
+vim.api.nvim_create_autocmd('LspAttach', {
+  desc = 'De-emphasize LSP string tokens in Python so Tree-sitter injections show',
+  callback = function(args)
+    if vim.bo[args.buf].filetype ~= 'python' then
+      return
+    end
+
+    -- Keep semantic tokens generally, but clear string tokens so injected SQL can show.
+    vim.api.nvim_set_hl(0, '@lsp.type.string.python', {})
+  end,
+})


### PR DESCRIPTION
## Summary
- add Tree-sitter SQL injection for Python strings
- adjust Python LSP semantic string highlighting to let injections show